### PR TITLE
Use dynamic spaces for running consumer tests

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -1,9 +1,16 @@
 steps:
   mtaBuild:
     buildTarget: 'CF'
+  cloudFoundryCreateSpace:
+    cfCredentialsId: "cf_deploy"
+    cfApiEndpoint: "https://api.cf.eu10.hana.ondemand.com"
+    cfOrg: "piper"
   cloudFoundryDeploy:
     cloudFoundry:
       credentialsId: 'cf_deploy'
       apiEndpoint: 'https://api.cf.eu10.hana.ondemand.com'
       org: 'piper'
-      space: 'infra-testing'
+  cloudFoundryDeleteSpace:
+    cfCredentialsId: "cf_deploy"
+    cfApiEndpoint: "https://api.cf.eu10.hana.ondemand.com"
+    cfOrg: "piper"

--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -1,7 +1,6 @@
 steps:
   mtaBuild:
     buildTarget: 'CF'
-    mtaBuildTool: 'classic'
   cloudFoundryDeploy:
     cloudFoundry:
       credentialsId: 'cf_deploy'

--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -1,16 +1,7 @@
+general:
+  cfApiEndpoint: "https://api.cf.eu10.hana.ondemand.com"
+  cfOrg: "piper"
+  cfCredentialsId: "cf_deploy"
 steps:
   mtaBuild:
     buildTarget: 'CF'
-  cloudFoundryCreateSpace:
-    cfCredentialsId: "cf_deploy"
-    cfApiEndpoint: "https://api.cf.eu10.hana.ondemand.com"
-    cfOrg: "piper"
-  cloudFoundryDeploy:
-    cloudFoundry:
-      credentialsId: 'cf_deploy'
-      apiEndpoint: 'https://api.cf.eu10.hana.ondemand.com'
-      org: 'piper'
-  cloudFoundryDeleteSpace:
-    cfCredentialsId: "cf_deploy"
-    cfApiEndpoint: "https://api.cf.eu10.hana.ondemand.com"
-    cfOrg: "piper"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,9 @@ node(){
       consumerTestsSpace = "consr-test-${id}"
 
       cloudFoundryCreateSpace script: this, cfSpace: consumerTestsSpace
-      cloudFoundryDeploy script:this, deployTool: 'mtaDeployPlugin', space: consumerTestsSpace
+      cloudFoundryDeploy script:this,
+                         deployTool: 'mtaDeployPlugin',
+                         cloudFoundry:[ space: consumerTestsSpace]
       cloudFoundryDeleteSpace script: this, cfSpace: consumerTestsSpace
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,8 +18,7 @@ node(){
       cloudFoundryCreateSpace script: this, cfSpace: consumerTestCfSpaceName
       cloudFoundryDeploy script:this,
                          deployTool: 'mtaDeployPlugin',
-                         cloudFoundry:[ space: consumerTestCfSpaceName]
+                         cfSpace: consumerTestCfSpaceName
       cloudFoundryDeleteSpace script: this, cfSpace: consumerTestCfSpaceName
   }
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,13 +13,13 @@ node(){
 
   stage('Deploy')   {
       def id = new Date().getTime()
-      consumerTestsSpace = "consr-test-${id}"
+      consumerTestCfSpaceName = "val-it-${id}"
 
-      cloudFoundryCreateSpace script: this, cfSpace: consumerTestsSpace
+      cloudFoundryCreateSpace script: this, cfSpace: consumerTestCfSpaceName
       cloudFoundryDeploy script:this,
                          deployTool: 'mtaDeployPlugin',
-                         cloudFoundry:[ space: consumerTestsSpace]
-      cloudFoundryDeleteSpace script: this, cfSpace: consumerTestsSpace
+                         cloudFoundry:[ space: consumerTestCfSpaceName]
+      cloudFoundryDeleteSpace script: this, cfSpace: consumerTestCfSpaceName
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,12 @@ node(){
   }
 
   stage('Deploy')   {
-      cloudFoundryDeploy script:this, deployTool: 'mtaDeployPlugin'
+      def id = new Date().getTime()
+      consumerTestsSpace = "consr-test-${id}"
+
+      cloudFoundryCreateSpace script: this, cfSpace: consumerTestsSpace
+      cloudFoundryDeploy script:this, deployTool: 'mtaDeployPlugin', space: consumerTestsSpace
+      cloudFoundryDeleteSpace script: this, cfSpace: consumerTestsSpace
   }
 }
 

--- a/mta.yaml
+++ b/mta.yaml
@@ -9,7 +9,7 @@ modules:
       memory: 1024M
       disk-quota: 256M
     build-parameters:
-      builder: maven
-      maven-opts:
-        command: [ clean, install ]
+      builder: custom
+      commands:
+        - mvn clean install
       build-result: target/*.war


### PR DESCRIPTION
Currently, the consumer tests are failing because of the parallel deployments to the same cf space. On the other hand, the test project still uses the old classic mta build tool.

Hence, this PR uses cloudmta build tool and creates dynamic spaces, deploys and deletes them in the end.